### PR TITLE
Refactor useEffect dependencies in PreviewComponent

### DIFF
--- a/src/components/PreviewComponent.tsx
+++ b/src/components/PreviewComponent.tsx
@@ -76,7 +76,7 @@ const PreviewComponent: React.FC<PreviewComponentProps> = ({
 	// Whenever the URL or color changes, reload the model
 	useEffect(() => {
 		loadModelAndCheckDimensions(url);
-	}, [url, color]);
+	}, [url]);
 
 	const initializeScene = () => {
 		renderer.setSize(600, 400); // Fixed size
@@ -177,6 +177,19 @@ const PreviewComponent: React.FC<PreviewComponentProps> = ({
 		scene.add(gridHelper);
 		gridHelperRef.current = gridHelper;
 	};
+
+	const updateMaterialColor = (hexColor: number) => {
+		if (meshRef.current) {
+			const material = new THREE.MeshStandardMaterial({ color: hexColor });
+			meshRef.current.material = material;
+		}
+	};
+
+	useEffect(() => {
+		if (modelLoaded) {
+			updateMaterialColor(parseInt(color.replace("#", ""), 16));
+		}
+	}, [color]);
 
 	const updateDimensions = () => {
 		const boundingBox = new THREE.Box3().setFromObject(meshRef.current!);


### PR DESCRIPTION
fixed issue #9

approach:

removed the "color" state from the first useEffect dependency at [Line 77](https://github.com/Pyramid-S-C-H-E-M-E-for-short/store/blob/2a1b17d42d391791bceb7231cb0e2e02baa060ce/src/components/PreviewComponent.tsx#L77) and added the code below to set the material color when the color state changes when a user clicks a color in the ColorPicker component:

```ts
	const updateMaterialColor = (hexColor: number) => {
		if (meshRef.current) {
			const material = new THREE.MeshStandardMaterial({ color: hexColor });
			meshRef.current.material = material;
		}
	};

	useEffect(() => {
		if (modelLoaded) {
			updateMaterialColor(parseInt(color.replace("#", ""), 16));
		}
	}, [color]);

```


tested the new changes in local env, network showing only the one fetch for the model, helping reduce api requests by 90%.